### PR TITLE
Bendy compatibility & Fix crash on missing SAO

### DIFF
--- a/Firmware/Supercon.8_Badge_Micropython/boot.py
+++ b/Firmware/Supercon.8_Badge_Micropython/boot.py
@@ -17,24 +17,23 @@ buttonB = Pin(9, Pin.IN, Pin.PULL_UP)
 buttonC = Pin(28, Pin.IN, Pin.PULL_UP)
 
 ## GPIOs
-gpio11 = Pin(7, Pin.OUT)
-gpio12 = Pin(6, Pin.OUT)
+# Set to input mode (0.8V) so Etch-sAo-sketch (I2C ADC on LIS3DH) and Bendy work properly.
+# If making use of some GPIO, make sure to initialize them otherwise. Set to Pin.OUT for 0V.
+gpio11 = Pin(7, Pin.IN)
+gpio12 = Pin(6, Pin.IN)
 
-gpio21 = Pin(5, Pin.OUT)
-gpio22 = Pin(4, Pin.OUT)
+gpio21 = Pin(5, Pin.IN)
+gpio22 = Pin(4, Pin.IN)
 
-gpio31 = Pin(3, Pin.OUT)
-gpio32 = Pin(2, Pin.OUT)
+gpio31 = Pin(3, Pin.IN)
+gpio32 = Pin(2, Pin.IN)
 
-gpio41 = Pin(22, Pin.OUT)
-gpio42 = Pin(21, Pin.OUT)
+gpio41 = Pin(22, Pin.IN)
+gpio42 = Pin(21, Pin.IN)
 
-gpio51 = Pin(20, Pin.OUT)
-gpio52 = Pin(19, Pin.OUT)
+gpio51 = Pin(20, Pin.IN)
+gpio52 = Pin(19, Pin.IN)
 
-# Etch-sAo-Sketch requires IN so that ADC works correctly
-#gpio61 = Pin(18, Pin.OUT)
-#gpio62 = Pin(17, Pin.OUT)
 gpio61 = Pin(18, Pin.IN)
 gpio62 = Pin(17, Pin.IN)
 

--- a/Firmware/Supercon.8_Badge_Micropython/etch_sao_sketch.py
+++ b/Firmware/Supercon.8_Badge_Micropython/etch_sao_sketch.py
@@ -5,11 +5,6 @@ import lis3dh_wrapper
 
 __version__ = '0.1.5'
 
-# GPIO pins to input so I2C ADC on LIS3DH on Etch-sAo-sketch works.
-# We assume SAO is connected to "port 6" (pin 17/18)
-gpio61 = Pin(18, Pin.IN)
-gpio62 = Pin(17, Pin.IN)
-
 class EtchSaoSketch():
     _display = None
     

--- a/Firmware/Supercon.8_Badge_Micropython/main.py
+++ b/Firmware/Supercon.8_Badge_Micropython/main.py
@@ -16,26 +16,27 @@ if petal_bus:
             time.sleep_ms(30)
             petal_bus.writeto_mem(PETAL_ADDRESS, i, bytes([which_leds]))
 
+print("\n\n*****Boot done*****\n\n")
+
 if etch_sao_sketch_device:
     etch_sao_sketch_device.shake() # clear display
 
-print("\n\n*****Boot done*****\n\n")
-if enable_calib:
-    # Calibrate after screen has started, to account for power drop caused by the OLED current draw
-    print("Starting ADC calibration routine:")
-    print("Within 5 seconds, in the following order")
-    print("1. Turn both knobs all the way right")
-    print("2. Turn both knobs all the way left")
-    success = etch_sao_sketch_device.try_calibration_routine()
-    if success:
-        print("ADC calibration succeeded.")
-        print(f"Calibration values: r={etch_sao_sketch_device.calib_right_zero_offset}, l={etch_sao_sketch_device.calib_left_zero_offset}, s={etch_sao_sketch_device.calib_voltage_scaling}")
-    else:
-        print("ADC calibration failed.")
-        print(f"Using default values: r={etch_sao_sketch_device.calib_right_zero_offset}, l={etch_sao_sketch_device.calib_left_zero_offset}, s={etch_sao_sketch_device.calib_voltage_scaling}")
+    if enable_calib:
+        # Calibrate after screen has started, to account for power drop caused by the OLED current draw
+        print("Starting ADC calibration routine:")
+        print("Within 5 seconds, in the following order")
+        print("1. Turn both knobs all the way right")
+        print("2. Turn both knobs all the way left")
+        success = etch_sao_sketch_device.try_calibration_routine()
+        if success:
+            print("ADC calibration succeeded.")
+            print(f"Calibration values: r={etch_sao_sketch_device.calib_right_zero_offset}, l={etch_sao_sketch_device.calib_left_zero_offset}, s={etch_sao_sketch_device.calib_voltage_scaling}")
+        else:
+            print("ADC calibration failed.")
+            print(f"Using default values: r={etch_sao_sketch_device.calib_right_zero_offset}, l={etch_sao_sketch_device.calib_left_zero_offset}, s={etch_sao_sketch_device.calib_voltage_scaling}")
 
-time.sleep(1)
-etch_sao_sketch_device.shake()
+    time.sleep(1)
+    etch_sao_sketch_device.shake()
 
 while True:
 


### PR DESCRIPTION
- Fix crash when Etch sAo Sketch is not connected to the badge
- Set all GPIOs to input mode for compatibility with Etch sAo Sketch and Bendy
  - So these add-ons can be freely plugged in any port on the badge

Note: Setting GPIO to Input mode will set it to 0.8V instead of 0V This is required to not prevent Bendy from booting, see https://github.com/bastlirna/hackaday2025_bsao_addon/blob/main/Readme.md which states:

> [!CAUTION]
> There is neccessary to keep pins `GP1` and `GP2` in `log1` (higher than 0.7 × VDD => approx. more than 2.1 Volts). There is internal 20-50kOhm pull-up in addon chip, so if you connect just power, it will work well. But this also means, if you connect this addon to your Hackaton 2025 badge, then you need drive these pins in you badge to `log1`. In case when you drive these pins to low, addon will be held in reset mode.