### PR TITLE
Added input averaging to lower the noise

### DIFF
--- a/Firmware/Supercon.8_Badge_Micropython/etch_sao_sketch.py
+++ b/Firmware/Supercon.8_Badge_Micropython/etch_sao_sketch.py
@@ -25,7 +25,9 @@ class EtchSaoSketch():
     
     @property
     def shake_detected(self):
+        # tapped is faster, shake takes too much time
         return self._lis3dh.tapped
+        #return self._lis3dh.shake(shake_threshold=19.5, avg_count=10)
     
     @property
     def rotation(self):

--- a/Firmware/Supercon.8_Badge_Micropython/etch_sao_sketch.py
+++ b/Firmware/Supercon.8_Badge_Micropython/etch_sao_sketch.py
@@ -139,7 +139,8 @@ class EtchSaoSketch():
             self._display.line(x1, y1, x2, y2, color)
     
     def draw_text(self, text, x, y, color):
-        self._display.text(text, x, y, color)
+        if self._display:
+            self._display.text(text, x, y, color)
         self.draw_display()
     
     def draw_display(self):

--- a/Firmware/Supercon.8_Badge_Micropython/lis3dh_wrapper.py
+++ b/Firmware/Supercon.8_Badge_Micropython/lis3dh_wrapper.py
@@ -67,6 +67,9 @@ class lis3dh_wrapper:
     @property
     def tapped(self):
         return self._imu.tapped
+    
+    def shake(self, shake_threshold=19.5, avg_count=100, total_delay=0.01):
+        return self._imu.shake(shake_threshold, avg_count, total_delay)
 
 # Example usage
 if __name__ == "__main__":    # If we have found the LIS3DH

--- a/Firmware/Supercon.8_Badge_Micropython/main.py
+++ b/Firmware/Supercon.8_Badge_Micropython/main.py
@@ -39,7 +39,7 @@ if etch_sao_sketch_device:
     etch_sao_sketch_device.shake()
 
 if etch_sao_sketch_device:
-    cycles = 20
+    cycles = 20 # 20 seems OK with fully populated badge, 40 is OK with only Etch sAo Sketch connected, but brings little additional benefit
     avg_cycles = cycles
     avg_left = 0
     avg_right = 0

--- a/Firmware/Supercon.8_Badge_Micropython/main.py
+++ b/Firmware/Supercon.8_Badge_Micropython/main.py
@@ -38,6 +38,16 @@ if etch_sao_sketch_device:
     time.sleep(1)
     etch_sao_sketch_device.shake()
 
+if etch_sao_sketch_device:
+    cycles = 20
+    avg_cycles = cycles
+    avg_left = 0
+    avg_right = 0
+    etch_left = etch_sao_sketch_device.left
+    etch_right = 127 - etch_sao_sketch_device.right
+    prev_left = etch_left
+    prev_right = etch_right
+
 while True:
 
     ## display button status on RGB
@@ -80,24 +90,25 @@ while True:
             print("Shake detected")
             etch_sao_sketch_device.shake()
 
-        if etch_left is not None:
-            prev_left = etch_left
-        else:
-            prev_left = None
-        if etch_right is not None:
-            prev_right = etch_right
-        else:
-            prev_right = None
+        avg_left += etch_sao_sketch_device.left
+        avg_right += 127 - etch_sao_sketch_device.right
+
+        if avg_cycles == 0:
+            etch_left = int(avg_left/cycles)
+            etch_right = int(avg_right/cycles)
         
-        etch_left = etch_sao_sketch_device.left
-        etch_right = 127 - etch_sao_sketch_device.right
-        
-        if prev_left is None:
+            etch_sao_sketch_device.draw_line(prev_left, prev_right, etch_left, etch_right, 15)
+            etch_sao_sketch_device.draw_display()
+
             prev_left = etch_left
-        if prev_right is None:
             prev_right = etch_right
 
-        etch_sao_sketch_device.draw_line( prev_left, prev_right, etch_left, etch_right, 15)
-        etch_sao_sketch_device.draw_display()
-    
+            avg_cycles = cycles
+            avg_left = 0
+            avg_right = 0
+        else:
+            avg_cycles -= 1
+
+
     bootLED.off()
+    #time.sleep_ms(20)


### PR DESCRIPTION
A configurable averaging is added to the input processing. A slight decrease in the responsivness is compensated by a less noisy input. Drawing every 20 cycles seems to be usable for a fully populated badge, while going up to 40 was still OK for me when only the Etch sAo Sketch was connected - but noise improvement was not so significant there anymore.